### PR TITLE
Update feature styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     container: 'map',
     zoom: 4,
     center: [0, 0],
-    style: 'https://www.mapbox.com/mapbox-gl-styles/styles/outdoors-v7.json'
+    style: 'https://www.mapbox.com/mapbox-gl-styles/styles/mapbox-streets-v7.json'
   });
 
   map.addControl(new mapboxgl.Navigation({

--- a/src/theme/edit.js
+++ b/src/theme/edit.js
@@ -15,28 +15,12 @@ module.exports = [
     },
     'interactive': true
   }, {
-    'id': 'gl-edit-points',
-    'type': 'symbol',
-    'source': 'edit',
-    'filter': ['all', ['==', '$type', 'Point']],
-    'layout': {
-      'icon-image': 'circle-stroked-12',
-      'text-anchor': 'top',
-      'icon-allow-overlap': true
-    },
-    'paint': {
-      'icon-color': '#f1f075',
-      'icon-size': 2
-    },
-    'interactive': true
-  }, {
     'id': 'gl-edit-polygon',
     'type': 'fill',
     'source': 'edit',
     'filter': ['all', ['==', '$type', 'Polygon']],
     'paint': {
       'fill-color': '#000000',
-      'fill-outline-color': '#000000',
       'fill-opacity': 0.25
     },
     'interactive': true
@@ -53,6 +37,42 @@ module.exports = [
       'line-color': '#000000',
       'line-dasharray': [2, 2],
       'line-width': 3
+    },
+    'interactive': true
+  }, {
+    'id': 'gl-edit-points',
+    'type': 'symbol',
+    'source': 'edit',
+    'filter': ['all',
+      ['==', '$type', 'Point'],
+      ['!=', 'meta', 'midpoint']],
+    'layout': {
+      'icon-image': 'circle.sdf',
+      'text-anchor': 'top',
+      'icon-allow-overlap': true
+    },
+    'paint': {
+      'icon-color': '#ffffff',
+      'icon-halo-color': '#000000',
+      'icon-halo-width': 2,
+      'icon-size': 1.1
+    },
+    'interactive': true
+  }, {
+    'id': 'gl-edit-points-mid',
+    'type': 'symbol',
+    'source': 'edit',
+    'filter': ['all',
+      ['==', '$type', 'Point'],
+      ['==', 'meta', 'midpoint']],
+    'layout': {
+      'icon-image': 'circle.sdf',
+      'text-anchor': 'top',
+      'icon-allow-overlap': true
+    },
+    'paint': {
+      'icon-color': '#000000',
+      'icon-size': 1
     },
     'interactive': true
   }

--- a/src/theme/style.js
+++ b/src/theme/style.js
@@ -44,14 +44,13 @@ module.exports = [
     'source': 'draw',
     'filter': ['all', ['==', '$type', 'Point']],
     'layout': {
-      'icon-image': 'marker-12',
+      'icon-image': 'circle.sdf',
       'text-anchor': 'top',
-      'icon-offset': [-0.5,-5],
       'icon-allow-overlap': true
     },
     'paint': {
       'icon-color': '#ff00ff',
-      'icon-size': 2
+      'icon-size': 1
     },
     'interactive': true
   }


### PR DESCRIPTION
- Uses `circle.sdf` for rendering points until circle types land in v8
- Switch to the streets style (which contains circles in the sprite)
- Styles midpoints in edit mode differently

![draw](https://cloud.githubusercontent.com/assets/1577766/9016829/ef59c81a-3788-11e5-94b0-f87b37e710d0.gif)