### PR TITLE
featuresIn and mass edits also major refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "hat": "0.0.3",
     "immutable": "^3.7.3",
     "mapbox-gl": "^0.9.0",
-    "ramda": "^0.17.1"
+    "ramda": "^0.17.1",
+    "turf-extent": "^1.0.4"
   }
 }

--- a/src/draw.js
+++ b/src/draw.js
@@ -271,7 +271,8 @@ export default class Draw extends mapboxgl.Control {
       }
 
       if (this.newVertex) {
-        this._control.editAddVertex(coords, this.newVertex.properties.index);
+        //this._control.editAddVertex(coords, this.newVertex.properties.index);
+        this._editStore.get(this.editId).editAddVertex(coords, this.newVertex.properties.index);
         this.vertex = this.newVertex;
       }
 
@@ -339,8 +340,7 @@ export default class Draw extends mapboxgl.Control {
   }
 
   _destroy(id) {
-    this._control.store.clear();
-    this.options.geoJSON.unset(id);
+    this._editStore.endEdit(id);
     this._exitEdit();
   }
 
@@ -357,7 +357,7 @@ export default class Draw extends mapboxgl.Control {
 
       var el = e.target;
 
-      if (this._control && !this.editId) this._control.completeDraw();
+      if (this._control && !this.editId) this._editStore.get(this.editId).completeDraw();//this._control.completeDraw();
 
       if (el.classList.contains('active')) {
         el.classList.remove('active');

--- a/src/draw.js
+++ b/src/draw.js
@@ -53,7 +53,7 @@ export default class Draw extends mapboxgl.Control {
     var controlClass = this._controlClass = 'mapboxgl-ctrl-draw-btn';
     var container = this._container = DOM.create('div', 'mapboxgl-ctrl-group', map.getContainer());
     var controls = this.options.controls;
-    this.options.geoJSON = new Store(map, this.options.geoJSON);
+    this._store = new Store(map, this.options.geoJSON);
     this._editStore = new EditStore(map);
 
     // Build out draw controls
@@ -169,7 +169,7 @@ export default class Draw extends mapboxgl.Control {
       new LatLng(sw.lat, sw.lng),
       new LatLng(ne.lat, ne.lng)
     );
-    var feats = this.options.geoJSON.getFeaturesIn(bounds);
+    var feats = this._store.getFeaturesIn(bounds);
     this._massEdit(feats.map(feat => feat.drawId));
   }
 
@@ -215,7 +215,7 @@ export default class Draw extends mapboxgl.Control {
 
   _edit(feature) {
     this.editId = feature.properties.drawId;
-    var feat = this.options.geoJSON.edit(this.editId);
+    var feat = this._store.edit(this.editId);
     this._editStore.add(feat);
 
     this._map.getContainer().addEventListener('mousedown', this.initiateDrag, true);
@@ -377,7 +377,7 @@ export default class Draw extends mapboxgl.Control {
     this._map.on('load', () => {
 
       this._map.addSource('draw', {
-        data: this.options.geoJSON.getAll(),
+        data: this._store.getAll(),
         type: 'geojson'
       });
 
@@ -398,7 +398,7 @@ export default class Draw extends mapboxgl.Control {
       });
 
       this._map.on('draw.end', e => {
-        this.options.geoJSON.set(e.geometry);
+        this._store.set(e.geometry);
         DOM.removeClass(document.querySelectorAll('.' + controlClass), 'active');
       });
 
@@ -448,7 +448,7 @@ export default class Draw extends mapboxgl.Control {
    * @param {Object} feature - GeoJSON feature
    */
   addGeometry(feature) {
-    this.options.geoJSON.set(feature);
+    this._store.set(feature);
   }
 
   /**
@@ -457,7 +457,7 @@ export default class Draw extends mapboxgl.Control {
    * @param {String} id - the drawid of the geometry
    */
   removeGeometry(id) {
-    this.options.geoJSON.unset(id);
+    this._store.unset(id);
   }
 
   /**
@@ -466,10 +466,10 @@ export default class Draw extends mapboxgl.Control {
    * @param {Object} featureCollection - a GeoJSON FeatureCollection
    */
   update(featureCollection) {
-    this.options.geoJSON.clear();
+    this._store.clear();
     var feats = featureCollection.features;
     for (var i = 0, ii = feats.length; i < ii; i++) {
-      this.options.geoJSON.set(feats[i]);
+      this._store.set(feats[i]);
     }
   }
 
@@ -479,7 +479,7 @@ export default class Draw extends mapboxgl.Control {
    * @param {String} id - the draw id of the geometry
    */
   get(id) {
-    return this.options.geoJSON.get(id);
+    return this._store.get(id);
   }
 
   /**
@@ -488,21 +488,21 @@ export default class Draw extends mapboxgl.Control {
    * @returns {Object} a GeoJSON feature collection
    */
   getAll() {
-    return this.options.geoJSON.getAll();
+    return this._store.getAll();
   }
 
   /**
    * remove all geometries
    */
   clear() {
-    this.options.geoJSON.clear();
+    this._store.clear();
   }
 
   /**
    * remove all geometries and clears the history
    */
   clearAll() {
-    this.options.geoJSON.clearAll();
+    this._store.clearAll();
   }
 
 }

--- a/src/draw.js
+++ b/src/draw.js
@@ -170,7 +170,7 @@ export default class Draw extends mapboxgl.Control {
       new LatLng(ne.lat, ne.lng)
     );
     var feats = this.options.geoJSON.getFeaturesIn(bounds);
-    this._massEdit(feats.map(feat => feat.properties.drawId));
+    this._massEdit(feats.map(feat => feat.drawId));
   }
 
   /**
@@ -240,7 +240,7 @@ export default class Draw extends mapboxgl.Control {
     if (this.editId) {
       this._editStore.get(this.editId).completeEdit();
     } else if (this._editStore.inProgress()) {
-      this._editStore.get(this.editId).completeDraw();
+      this._editStore.getAll()[0].completeDraw(); // REVISIT BRUH
     }
   }
 
@@ -418,7 +418,7 @@ export default class Draw extends mapboxgl.Control {
         //////////////////////////////////////////////////////////////////////
         //////////// FIX THIS WHEN MULTIPLE LAYER QUERIES LAND ///////////////
         //////////////////////////////////////////////////////////////////////
-        this._map.featuresAt(e.point, { radius: 7, layer: 'gl-edit-points' }, (err, features) => {
+        this._map.featuresAt(e.point, { radius: 7, layer: ['gl-edit-points'/*, 'gl-draw-polygons'*/] }, (err, features) => {
           if (err) throw err;
           if (!features.length) return this._map.getContainer().classList.remove('mapboxgl-draw-move-activated');
 
@@ -438,9 +438,9 @@ export default class Draw extends mapboxgl.Control {
 
   }
 
-  /***************/
-  /* API Methods */
-  /***************/
+  //****************//
+  //  API Methods   //
+  //****************//
 
   /**
    * add a geometry

--- a/src/draw.js
+++ b/src/draw.js
@@ -206,13 +206,13 @@ export default class Draw extends mapboxgl.Control {
       }
 
       // if (clicked on a feature && ((!editing this feature && !drawing))
-      this._edit(features[0]);
+      this._edit(features[0].properties.drawId);
     });
 
   }
 
-  _edit(feature) {
-    this.editId = feature.properties.drawId;
+  _edit(drawId) {
+    this.editId = drawId;
     var feat = this._store.edit(this.editId);
     this._editStore.add(feat);
 
@@ -231,7 +231,9 @@ export default class Draw extends mapboxgl.Control {
    * @private
    */
   _massEdit(drawIds) {
-    console.log(drawIds);
+    for (var i = 0; i < drawIds.length; i++) {
+      this._edit(drawIds[i]);
+    }
   }
 
   _finish() {

--- a/src/draw.js
+++ b/src/draw.js
@@ -66,7 +66,6 @@ export default class Draw extends mapboxgl.Control {
       });
     }
 
-    /*
     if (controls.shape) {
       this.polygonCtrl = this._createButton({
         className: `${controlClass} shape`,
@@ -76,7 +75,6 @@ export default class Draw extends mapboxgl.Control {
       });
     }
 
-    */
     if (controls.square) {
       this.squareCtrl = this._createButton({
         className: `${controlClass} square`,

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -12,22 +12,59 @@
  */
 export default class EditStore {
 
+  /*
   constructor(map, features) {
     this._map = map;
     this.features = features;
     if (this.features[0].geometry.coordinates.length)
       this.features.forEach(feat => this.update(feat));
   }
+  */
+
+  constructor(map, features) {
+    this._map = map;
+    this.features = features || [];
+
+    this._map.on('new.edit', () => {
+      this.render();
+    });
+
+    this._map.on('finish.edit', () => {
+      this.features = [];
+      this.render();
+    });
+
+    this._map.on('edit.end', e => {
+      this.endEdit(e.geometry.drawId);
+      this.render();
+    });
+  }
+
+  add(geometry) {
+    ////////////////////////////////////////////////////////
+    ///////////////// CHECK FOR DUPES!!! ///////////////////
+    ////////////////////////////////////////////////////////
+    if (geometry instanceof Array) {
+      this.features = this.features.concat(geometry);
+    } else {
+      this.features.push(geometry);
+    }
+    this.render();
+  }
 
   getAll() {
     return {
       type: 'FeatureCollection',
-      features: this.features
+      features: this.features.map(feature => feature.geojson.toJS())
     };
   }
 
-  getById(id) {
-    return this.features.filter(feat => feat.properties.drawId === id)[0];
+  get(id) {
+    return this.features.filter(feat => feat.drawId === id)[0];
+  }
+
+  endEdit(id) {
+    this.features = this.features.filter(feat => feat.drawId !== id);
   }
 
   clear() {
@@ -35,19 +72,16 @@ export default class EditStore {
     this.render();
   }
 
-  update(feature) {
-    this.features = this.features
-      .filter(feat => feat.properties.drawId !== feature.properties.drawId);
-    this.features.push(feature);
-    this.render();
+  isEditting() {
+    return this.features.length > 0;
   }
 
   _addVertices() {
     var vertices = [];
 
     for (var i = 0; i < this.features.length; i++) {
-      var coords = this.features[i].geometry.coordinates;
-      var type = this.features[i].geometry.type;
+      var coords = this.features[i].get().geometry.coordinates;
+      var type = this.features[i].get().geometry.type;
       if (type === 'LineString' || type === 'Polygon') {
         coords = type === 'Polygon' ? coords[0] : coords;
         var l = type === 'LineString' ? coords.length : coords.length - 1;
@@ -74,13 +108,15 @@ export default class EditStore {
     var midpoints = [];
 
     for (var i = 0; i < this.features.length; i++) {
+      if (this.features[i].type === 'square') continue;
+
       var feat = this.features[i];
-      var c = feat.geometry.coordinates;
+      var c = feat.get().geometry.coordinates;
 
-      if (feat.geometry.type === 'LineString' ||
-          feat.geometry.type === 'Polygon' && c[0][0][0] !== c[0][1][0]) {
+      if (feat.get().geometry.type === 'LineString' ||
+          feat.get().geometry.type === 'Polygon') {
 
-        c = feat.geometry.type === 'Polygon' ? c[0] : c;
+        c = feat.get().geometry.type === 'Polygon' ? c[0] : c;
 
         for (var j = 0; j < c.length - 1; j++) {
           var ptA = this._map.project([ c[j][1], c[j][0] ]);

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -8,18 +8,9 @@
  * @param {Map} map - an instance of mapboxgl.Map
  * @param {Array<Object>} [features] - an array of geojson features
  * @returns {EditStore} this
- *
+ * @private
  */
 export default class EditStore {
-
-  /*
-  constructor(map, features) {
-    this._map = map;
-    this.features = features;
-    if (this.features[0].geometry.coordinates.length)
-      this.features.forEach(feat => this.update(feat));
-  }
-  */
 
   constructor(map, features) {
     this._map = map;
@@ -72,7 +63,7 @@ export default class EditStore {
     this.render();
   }
 
-  isEditting() {
+  inProgress() {
     return this.features.length > 0;
   }
 

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -49,7 +49,7 @@ export default class EditStore {
   getAllGeoJSON() {
     return {
       type: 'FeatureCollection',
-      features: this.features.map(feature => feature.geojson.toJS())
+      features: this.features.map(feature => feature.getGeoJSON())
     };
   }
 
@@ -75,8 +75,8 @@ export default class EditStore {
     var vertices = [];
 
     for (var i = 0; i < this.features.length; i++) {
-      var coords = this.features[i].get().geometry.coordinates;
-      var type = this.features[i].get().geometry.type;
+      var coords = this.features[i].getGeoJSON().geometry.coordinates;
+      var type = this.features[i].getGeoJSON().geometry.type;
       if (type === 'LineString' || type === 'Polygon') {
         coords = type === 'Polygon' ? coords[0] : coords;
         var l = type === 'LineString' ? coords.length : coords.length - 1;
@@ -106,12 +106,12 @@ export default class EditStore {
       if (this.features[i].type === 'square') continue;
 
       var feat = this.features[i];
-      var c = feat.get().geometry.coordinates;
+      var c = feat.getGeoJSON().geometry.coordinates;
 
-      if (feat.get().geometry.type === 'LineString' ||
-          feat.get().geometry.type === 'Polygon') {
+      if (feat.getGeoJSON().geometry.type === 'LineString' ||
+          feat.getGeoJSON().geometry.type === 'Polygon') {
 
-        c = feat.get().geometry.type === 'Polygon' ? c[0] : c;
+        c = feat.getGeoJSON().geometry.type === 'Polygon' ? c[0] : c;
 
         for (var j = 0; j < c.length - 1; j++) {
           var ptA = this._map.project([ c[j][1], c[j][0] ]);

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -43,6 +43,10 @@ export default class EditStore {
   }
 
   getAll() {
+    return this.features;
+  }
+
+  getAllGeoJSON() {
     return {
       type: 'FeatureCollection',
       features: this.features.map(feature => feature.geojson.toJS())
@@ -133,7 +137,7 @@ export default class EditStore {
   }
 
   render() {
-    var geom = this.getAll();
+    var geom = this.getAllGeoJSON();
     geom.features = geom.features.concat(this._addVertices(), this._addMidpoints());
     this._map.fire('edit.feature.update', {
       geojson: geom

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -36,7 +36,6 @@ export default class EditStore {
 
     this._map.on('edit.end', e => {
       this.endEdit(e.geometry.drawId);
-      this.render();
     });
   }
 
@@ -65,6 +64,7 @@ export default class EditStore {
 
   endEdit(id) {
     this.features = this.features.filter(feat => feat.drawId !== id);
+    this.render();
   }
 
   clear() {

--- a/src/geometries/geometry.js
+++ b/src/geometries/geometry.js
@@ -75,6 +75,10 @@ export default class Geometry {
 
     var translatedGeom = translate(JSON.parse(JSON.stringify(this.initGeom)), init, curr, this._map);
     this.coordinates = Immutable.List(translatedGeom.geometry.coordinates);
+    if (this.coordinates.get(0).length > 1) {
+      // you should be ashamed of yourself
+      this.coordinates = this.coordinates.set(0, Immutable.List(this.coordinates.get(0)));
+    }
 
     this._map.fire('new.edit');
   }

--- a/src/geometries/geometry.js
+++ b/src/geometries/geometry.js
@@ -2,7 +2,6 @@
 
 import hat from 'hat';
 import Immutable from 'immutable';
-//import EditStore from '../edit_store';
 import { translate } from '../util';
 import { LatLng, LatLngBounds } from 'mapbox-gl';
 import extent from 'turf-extent';
@@ -19,10 +18,10 @@ import extent from 'turf-extent';
  */
 export default class Geometry {
 
-  constructor(map, type) {
+  constructor(map, type, coordinates) {
     this._map = map;
     this.drawId = hat();
-    this.coordinates = Immutable.fromJS([[[0, 0],[0, 0], [0, 0], [0, 0]]]);
+    this.coordinates = coordinates;
 
     this.geojson = Immutable.fromJS({
       type: 'Feature',

--- a/src/geometries/geometry.js
+++ b/src/geometries/geometry.js
@@ -58,7 +58,6 @@ export default class Geometry {
    * Clear the edit drawings and render the changes to the main draw layer
    */
   completeEdit() {
-    //this.drawStore.set(this.geojson.toJS());
     this._map.fire('edit.end', { geometry: this });
   }
 

--- a/src/geometries/line.js
+++ b/src/geometries/line.js
@@ -40,8 +40,8 @@ export default class Line extends Geometry {
       this.vertexIdx = 0;
     } else {
       this.coordinates = this.coordinates.splice(-1, 1, p, p);
-      this.vertexIdx++;
     }
+    this.vertexIdx++;
 
     this._map.fire('new.edit');
   }
@@ -49,8 +49,7 @@ export default class Line extends Geometry {
   _onMouseMove(e) {
     var pos = DOM.mousePos(e, this._map._container);
     var coords = this._map.unproject([pos.x, pos.y]);
-    this.coordinates = this.coordinates.set(this.vertexIdx + 1,[ coords.lng, coords.lat ]);
-    console.log(JSON.stringify(this.coordinates));
+    this.coordinates = this.coordinates.set(this.vertexIdx,[ coords.lng, coords.lat ]);
 
     this._map.fire('new.edit');
   }
@@ -61,7 +60,7 @@ export default class Line extends Geometry {
     this._map.off('dblclick', this.completeDraw);
     this._map.getContainer().removeEventListener('mousemove', this.onMouseMove);
 
-    this.coordinates = this.coordinates.delete(this.vertexIdx + 1);
+    this.coordinates = this.coordinates.remove(this.vertexIdx);
 
     this._done('line');
   }

--- a/src/geometries/line.js
+++ b/src/geometries/line.js
@@ -8,9 +8,8 @@ import { translatePoint, DOM } from '../util';
  * Line geometry class
  *
  * @param {Object} map - Instance of MapboxGL Map
- * @param {Object} drawStore - The overall drawStore for this session
- * @param {Object} [data] - GeoJSON line string feature
  * @returns {Line} this
+ * @private
  */
 export default class Line extends Geometry {
 

--- a/src/geometries/point.js
+++ b/src/geometries/point.js
@@ -28,7 +28,7 @@ export default class Point extends Geometry {
   _completeDraw(e) {
     this._map.getContainer().classList.remove('mapboxgl-draw-activated');
     this._map.off('click', this.completeDraw);
-    this.geojson = this.geojson.setIn(['geometry', 'coordinates'], [ e.latLng.lng, e.latLng.lat ]);
+    this.coordinates = Immutable.List([ e.latLng.lng, e.latLng.lat ]);
     this._done('point');
   }
 

--- a/src/geometries/point.js
+++ b/src/geometries/point.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Geometry from './geometry';
+import Immutable from 'immutable';
 
 /**
  * Point geometry class
@@ -13,7 +14,8 @@ import Geometry from './geometry';
 export default class Point extends Geometry {
 
   constructor(map) {
-    super(map, 'Point');
+    var coordinates = Immutable.List([0, 0]);
+    super(map, 'Point', coordinates);
     this.type = 'point';
     this.completeDraw = this._completeDraw.bind(this);
   }

--- a/src/geometries/point.js
+++ b/src/geometries/point.js
@@ -12,8 +12,9 @@ import Geometry from './geometry';
  */
 export default class Point extends Geometry {
 
-  constructor(map, drawStore, data) {
-    super(map, drawStore, 'Point', data);
+  constructor(map) {
+    super(map, 'Point');
+    this.type = 'point';
     this.completeDraw = this._completeDraw.bind(this);
   }
 
@@ -26,7 +27,7 @@ export default class Point extends Geometry {
   _completeDraw(e) {
     this._map.getContainer().classList.remove('mapboxgl-draw-activated');
     this._map.off('click', this.completeDraw);
-    this.feature = this.feature.setIn(['geometry', 'coordinates'], [ e.latLng.lng, e.latLng.lat ]);
+    this.geojson = this.geojson.setIn(['geometry', 'coordinates'], [ e.latLng.lng, e.latLng.lat ]);
     this._done('point');
   }
 

--- a/src/geometries/point.js
+++ b/src/geometries/point.js
@@ -7,9 +7,8 @@ import Immutable from 'immutable';
  * Point geometry class
  *
  * @param {Object} map - Instance of MpaboxGL Map
- * @param {Object} drawStore - The draw store for this session
- * @param {Object} [data] - GeoJSON polygon feature
  * @returns {Point} this
+ * @private
  */
 export default class Point extends Geometry {
 

--- a/src/geometries/polygon.js
+++ b/src/geometries/polygon.js
@@ -8,20 +8,19 @@ import { translatePoint, DOM } from '../util';
  * Polygon geometry class
  *
  * @param {Object} map - Instance of MapboxGl Map
- * @param {Object} drawStore - The drawStore for this session
- * @param {Object} [data] - GeoJSON polygon feature
  * @returns {Polygon} this
+ * @private
  */
 export default class Polygon extends Geometry {
 
-  constructor(map, drawStore, data) {
-    super(map, drawStore, 'Polygon', data);
+  constructor(map) {
+    var coordinates = Immutable.fromJS([[[0, 0],[0, 0], [0, 0], [0, 0]]]);
+    super(map, 'Polygon', coordinates);
 
     // event handlers
     this.addVertex = this._addVertex.bind(this);
     this.onMouseMove = this._onMouseMove.bind(this);
     this.completeDraw = this._completeDraw.bind(this);
-
   }
 
 
@@ -35,28 +34,37 @@ export default class Polygon extends Geometry {
   _addVertex(e) {
     var p = [ e.latLng.lng, e.latLng.lat ];
 
-    if (this.editting) {
-      var c = this.coordinates.get(0).splice(-1, 0, p);
-      this.coordinates = this.coordinates.set(0, c);
-    } else {
-      this.editting = true;
-      this.coordinates = Immutable.fromJS([[ p, p ]]);
+    if (typeof this.vertexIdx === 'undefined') {
+      this.vertexIdx = 0;
+      this.first = p;
+      this.coordinates = Immutable.fromJS([[p, p, p, p]]);
       this._map.getContainer().addEventListener('mousemove', this.onMouseMove);
+    } else {
+      this.vertexIdx++;
     }
 
-    this.feature = this.feature.setIn(['geometry', 'coordinates'], this.coordinates);
-    this.store.update(this.feature.toJS());
+    this.coordinates = this.coordinates.setIn([0, this.vertexIdx], p);
+
+    if (this.vertexIdx > 2) {
+      this.coordinates = this.coordinates.setIn([0, this.vertexIdx + 1], p);
+      this.coordinates = this.coordinates.setIn([0, this.vertexIdx + 2], this.first);
+    }
+
+    this._map.fire('new.edit');
   }
 
   _onMouseMove(e) {
     var pos = DOM.mousePos(e, this._map._container);
     var coords = this._map.unproject([pos.x, pos.y]);
-    var c = this.coordinates.get(0).splice(-1, 0, [ coords.lng, coords.lat ]);
-    var temp = this.coordinates.set(0, c);
-    this.store.update(this.feature.setIn(['geometry', 'coordinates'], temp).toJS());
+    this.coordinates = this.coordinates.setIn([0, this.vertexIdx + 1], [coords.lng, coords.lat]);
+
+    this._map.fire('new.edit');
   }
 
   _completeDraw() {
+    if (this.vertexIdx > 2)
+      this.coordinates = this.coordinates.delete(this.vertexIdx + 1);
+
     this._map.getContainer().classList.remove('mapboxgl-draw-activated');
     this._map.off('click', this.addVertex);
     this._map.off('dblclick', this.completeDraw);
@@ -72,22 +80,23 @@ export default class Polygon extends Geometry {
    * @param {Array<Number>} init - the position of the mouse at the start of the drag
    * @param {Array<Number>} curr - the current position of the mouse
    * @param {Number} idx - the index of the point being updated in `feature.geometry.coordinates`
+   * @private
    */
   moveVertex(init, curr, idx) {
     if (!this.movingVertex) {
       this.movingVertex = true;
-      this.initCoords = this.feature.getIn(['geometry', 'coordinates', 0, idx]);
+      this.initCoords = this.coordinates.getIn([0, idx]);
     }
 
     var dx = curr.x - init.x;
     var dy = curr.y - init.y;
-    var newPoint = translatePoint(this.initCoords.toJS(), dx, dy, this._map);
+    var newPoint = translatePoint(this.initCoords, dx, dy, this._map);
 
-    this.feature = this.feature.setIn(['geometry', 'coordinates', 0, idx], Immutable.fromJS(newPoint));
+    this.coordinates = this.coordinates.setIn([0, idx], Immutable.fromJS(newPoint));
     if (idx === 0)
-      this.feature = this.feature.setIn(['geometry', 'coordinates', 0, -1], Immutable.fromJS(newPoint));
+      this.coordinates = this.coordinates.setIn([0, -1], Immutable.fromJS(newPoint));
 
-    this.store.update(this.feature.toJS());
+    this._map.fire('new.edit');
   }
 
   /**
@@ -95,12 +104,14 @@ export default class Polygon extends Geometry {
    *
    * @param {Object} coords - The coordinates of the new vertex in the for { lng: <Number>, lat: <Number> }
    * @param {Number} idx - the index at which the new point will be placed in `feature.geometry.coordinates`
+   * @private
    */
   editAddVertex(coords, idx) {
     coords = this._map.unproject(coords);
-    var newCoords = this.feature.getIn(['geometry', 'coordinates', 0]).splice(idx, 0, Immutable.fromJS([ coords.lng, coords.lat ]));
-    this.feature = this.feature.setIn(['geometry', 'coordinates', 0], newCoords);
-    this.store.update(this.feature.toJS());
+    var newCoords = this.coordinates.get(0).splice(idx, 0, Immutable.fromJS([ coords.lng, coords.lat ]));
+    this.coordinates = this.coordinates.set(0, newCoords);
+
+    this._map.fire('new.edit');
   }
 
 }

--- a/src/geometries/square.js
+++ b/src/geometries/square.js
@@ -14,8 +14,10 @@ import { translatePoint, DOM } from '../util';
  */
 export default class Square extends Geometry {
 
-  constructor(map, drawStore, data) {
-    super(map, drawStore, 'Polygon', data);
+  constructor(map) {
+    super(map, 'Polygon');
+
+    this.type = 'square';
 
     // event handlers
     this.onMouseDown = this._onMouseDown.bind(this);
@@ -33,14 +35,14 @@ export default class Square extends Geometry {
     this._map.getContainer().removeEventListener('mousedown', this.onMouseDown, true);
     this._map.getContainer().addEventListener('mousemove', this.onMouseMove, true);
 
-    var pos = DOM.mousePos(e, this._map._container);
+    var pos = DOM.mousePos(e, this._map.getContainer());
     var c = this._map.unproject([pos.x, pos.y]);
     var arr = [];
     var i = -1;
     while (++i < 5) {
       arr.push([ c.lng, c.lat]);
     }
-    this.coordinates = this.coordinates.push(Immutable.fromJS(arr));
+    this.coordinates = this.coordinates.set(0, Immutable.fromJS(arr));
   }
 
   _onMouseMove(e) {
@@ -59,8 +61,8 @@ export default class Square extends Geometry {
     this.coordinates = this.coordinates.setIn([0, 2], [ c.lng, c.lat ]);
     this.coordinates = this.coordinates.setIn([0, 3], [ c.lng, orig.get(1)]);
 
-    this.feature = this.feature.setIn(['geometry', 'coordinates'], this.coordinates);
-    this.store.update(this.feature.toJS());
+    this.geojson = this.geojson.setIn(['geometry', 'coordinates'], this.coordinates);
+    this._map.fire('new.edit');
   }
 
   _completeDraw() {
@@ -74,42 +76,41 @@ export default class Square extends Geometry {
   moveVertex(init, curr, idx) {
     if (!this.movingVertex) {
       this.movingVertex = true;
-      this.initCoords = this.feature.getIn(['geometry', 'coordinates', 0, idx]);
+      this.initCoords = this.geojson.getIn(['geometry', 'coordinates', 0, idx]);
     }
 
     var dx = curr.x - init.x;
     var dy = curr.y - init.y;
     var newPoint = translatePoint(this.initCoords.toJS(), dx, dy, this._map);
 
-
-    this.feature = this.feature.setIn(['geometry', 'coordinates', 0, idx], Immutable.fromJS(newPoint));
+    this.geojson = this.geojson.setIn(['geometry', 'coordinates', 0, idx], Immutable.fromJS(newPoint));
 
     var x = newPoint[0];
     var y = newPoint[1];
 
     switch (idx) {
       case 0:
-        this.feature = this._setV(1, [ x, this._getV(1).get(1) ]);
-        this.feature = this._setV(3, [ this._getV(3).get(0), y ]);
+        this.geojson = this._setV(1, [ x, this._getV(1).get(1) ]);
+        this.geojson = this._setV(3, [ this._getV(3).get(0), y ]);
         break;
       case 1:
-        this.feature = this._setV(0, [ x, this._getV(0).get(1) ]);
-        this.feature = this._setV(2, [ this._getV(2).get(0), y ]);
+        this.geojson = this._setV(0, [ x, this._getV(0).get(1) ]);
+        this.geojson = this._setV(2, [ this._getV(2).get(0), y ]);
         break;
       case 2:
-        this.feature = this._setV(1, [ this._getV(1).get(0), y ]);
-        this.feature = this._setV(3, [ x, this._getV(3).get(1) ]);
+        this.geojson = this._setV(1, [ this._getV(1).get(0), y ]);
+        this.geojson = this._setV(3, [ x, this._getV(3).get(1) ]);
         break;
       case 3:
-        this.feature = this._setV(0, [ this._getV(0).get(0), y ]);
-        this.feature = this._setV(2, [ x, this._getV(2).get(1) ]);
+        this.geojson = this._setV(0, [ this._getV(0).get(0), y ]);
+        this.geojson = this._setV(2, [ x, this._getV(2).get(1) ]);
         break;
     }
 
     // always reset last point to equal the first point
-    this.feature = this._setV(4, this._getV(0).toJS());
+    this.geojson = this._setV(4, this._getV(0).toJS());
 
-    this.store.update(this.feature.toJS());
+    this._map.fire('new.edit');
   }
 
   /**
@@ -121,7 +122,7 @@ export default class Square extends Geometry {
    * @private
    */
   _setV(idx, val) {
-    return this.feature.setIn(['geometry', 'coordinates', 0, idx], Immutable.fromJS(val));
+    return this.geojson.setIn(['geometry', 'coordinates', 0, idx], Immutable.fromJS(val));
   }
 
   /**
@@ -132,7 +133,7 @@ export default class Square extends Geometry {
    * @private
    */
   _getV(idx) {
-    return this.feature.getIn(['geometry', 'coordinates', 0, idx]);
+    return this.geojson.getIn(['geometry', 'coordinates', 0, idx]);
   }
 
 }

--- a/src/geometries/square.js
+++ b/src/geometries/square.js
@@ -60,6 +60,8 @@ export default class Square extends Geometry {
     this.coordinates = this.coordinates.setIn([0, 1], [ orig.get(0), c.lat ]);
     this.coordinates = this.coordinates.setIn([0, 2], [ c.lng, c.lat ]);
     this.coordinates = this.coordinates.setIn([0, 3], [ c.lng, orig.get(1)]);
+    // MAKE THIS BETTER
+    this.coordinates = Immutable.fromJS(this.coordinates.toJS());
 
     this.geojson = this.geojson.setIn(['geometry', 'coordinates'], this.coordinates);
     this._map.fire('new.edit');

--- a/src/geometries/square.js
+++ b/src/geometries/square.js
@@ -15,7 +15,8 @@ import { translatePoint, DOM } from '../util';
 export default class Square extends Geometry {
 
   constructor(map) {
-    super(map, 'Polygon');
+    var coordinates = Immutable.fromJS([[[0, 0],[0, 0], [0, 0], [0, 0]]]);
+    super(map, 'Polygon', coordinates);
 
     this.type = 'square';
 

--- a/src/store.js
+++ b/src/store.js
@@ -51,7 +51,7 @@ export default class Store {
   getAllGeoJSON() {
     return {
       type: 'FeatureCollection',
-      features: this.history[this.historyIndex].map(feature => feature.geojson.toJS()).toJS()
+      features: this.history[this.historyIndex].map(feature => feature.getGeoJSON()).toJS()
     };
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -61,7 +61,7 @@ export default class Store {
 
   getFeaturesIn(bounds) {
     var results = [];
-    var features = this.getAll().features;
+    var features = this.history[this.historyIndex].map(feat => feat.geojson.toJS()).toJS();
     for (var i = 0; i < features.length; i++) {
       var ext = extent(features[i]);
       ext = new LatLngBounds(

--- a/src/store.js
+++ b/src/store.js
@@ -69,6 +69,7 @@ export default class Store {
         results.push(features[i]);
       }
     }
+    return results;
   }
 
   clear() {

--- a/src/store.js
+++ b/src/store.js
@@ -90,13 +90,6 @@ export default class Store {
     this.annotations = Immutable.List([]);
   }
 
-  unset(id) {
-    this.operation(
-      data => data.filterNot(feature => feature.drawId === id),
-      'Removed a feature'
-    );
-  }
-
   /**
    * @param {Object} feature - GeoJSON feature
    */

--- a/src/store.js
+++ b/src/store.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { LatLng, LatLngBounds } from 'mapbox-gl';
+//import { LatLng, LatLngBounds } from 'mapbox-gl';
 import Immutable from 'immutable';
-import extent from 'turf-extent';
+//import extent from 'turf-extent';
 
 /**
  * A store for keeping track of versions of drawings
@@ -61,20 +61,16 @@ export default class Store {
 
   getFeaturesIn(bounds) {
     var results = [];
-    var features = this.history[this.historyIndex].map(feat => feat.geojson.toJS()).toJS();
-    for (var i = 0; i < features.length; i++) {
-      var ext = extent(features[i]);
-      ext = new LatLngBounds(
-        new LatLng(ext[1], ext[0]),
-        new LatLng(ext[3], ext[2])
-      );
+    var features = this.history[this.historyIndex];
+    for (var i = 0; i < features.size; i++) {
+      var ext = features.get(i).getExtent();
       if (bounds.getNorth() < ext.getSouth() ||
           bounds.getSouth() > ext.getNorth() ||
           bounds.getEast() < ext.getWest() ||
           bounds.getWest() > ext.getEast()) {
         continue;
       } else {
-        results.push(features[i]);
+        results.push(features.get(i));
       }
     }
     return results;

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,8 @@
 'use strict';
 
+import { LatLng, LatLngBounds } from 'mapbox-gl';
 import Immutable from 'immutable';
+import extent from 'turf-extent';
 import hat from 'hat';
 
 /**
@@ -47,6 +49,26 @@ export default class Store {
   get(id) {
     return this.history[this.historyIndex]
       .find(feature => feature.get('properties').get('drawId') === id).toJS();
+  }
+
+  getFeaturesIn(bounds) {
+    var results = [];
+    var features = this.getAll().features;
+    for (var i = 0; i < features.length; i++) {
+      var ext = extent(features[i]);
+      ext = new LatLngBounds(
+        new LatLng(ext[1], ext[0]),
+        new LatLng(ext[3], ext[2])
+      );
+      if (bounds.getNorth() < ext.getSouth() ||
+          bounds.getSouth() > ext.getNorth() ||
+          bounds.getEast() < ext.getWest() ||
+          bounds.getWest() > ext.getEast()) {
+        continue;
+      } else {
+        results.push(features[i]);
+      }
+    }
   }
 
   clear() {


### PR DESCRIPTION
In trying to implement mass edits it has come to my attention that there are several things that can be done much better namely that stores should hold an array of `Geometry` types, not just geojson objects. This will simplify the edit code greatly. `Geometry` instances will have a `this.drawId` member constant and a `this.feature` member variable (in addition to the current methods). This way, don't have to re-instantiate `Geometry` types every time we edit.

In general, we need a greater separation of concerns across the board (a more flow-based approach).

- [x] store `Geometry` types in the store
- [x] move EditStore control out of indie geoms and into draw.js
- [x] make the EditStore persistent
- [x] `Geometry` classes shouldn't call store or editStore methods
- [x] make `this.geojson` a regular object but keep `this.coordinates` Immutable(?)
    - [x] adjust `this.coordinates` in Geomertries (not all of `this.geojson`)
- [x] eliminate `this._control`
- [x] `this.options.geoJSON` -> `this.store` https://github.com/mapbox/gl-draw/issues/69

Also
- limits the scope of group edits to just deleting features...for now ;)
- severely reduces the number of `toJS` and `fromJS` calls across the board for a performance boost

re: #4 #69 