### PR TITLE
Drawing and editting refactor

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -20,7 +20,7 @@
 
   var map = new mapboxgl.Map({
     container: 'map',
-    zoom: 2,
+    zoom: 1,
     center: [0, 0],
     style: 'mapbox://styles/mapbox/streets-v8'
   });

--- a/src/draw.js
+++ b/src/draw.js
@@ -36,7 +36,6 @@ export default class Draw extends mapboxgl.Control {
 
     mapboxgl.util.setOptions(this, options);
 
-
     // event listeners
     this.drag = this._drag.bind(this);
     this.onClick = this._onClick.bind(this);
@@ -165,7 +164,7 @@ export default class Draw extends mapboxgl.Control {
     }, (err, features) => {
       if (err) throw err;
       if (features.length) { // clicked on a feature
-        if (this._editStore.drawing) return;
+        if (this._drawing) return;
         this._edit(features[0].properties.drawId);
       } else { // clicked outside all features
         this._finishEdit();
@@ -267,24 +266,28 @@ export default class Draw extends mapboxgl.Control {
     this._finishEdit();
     var polygon = new Polygon(this._map);
     polygon.startDraw();
+    this._drawing = true;
   }
 
   _drawLine() {
     this._finishEdit();
     var line = new Line(this._map);
     line.startDraw();
+    this._drawing = true;
   }
 
   _drawSquare() {
     this._finishEdit();
     var square = new Square(this._map);
     square.startDraw();
+    this._drawing = true;
   }
 
   _drawPoint() {
     this._finishEdit();
     var point = new Point(this._map);
     point.startDraw();
+    this._drawing = true;
   }
 
   _createButton(opts) {
@@ -362,6 +365,7 @@ export default class Draw extends mapboxgl.Control {
           type: 'FeatureCollection',
           features: []
         });
+        this._drawing = false;
       });
 
       this._map.on('edit.feature.update', e => {
@@ -489,15 +493,6 @@ export default class Draw extends mapboxgl.Control {
    */
   clear() {
     this._store.clear();
-    return this;
-  }
-
-  /**
-   * remove all geometries and clears the history
-   * @returns {Draw} this
-   */
-  clearAll() {
-    this._store.clearAll();
     return this;
   }
 

--- a/src/draw.js
+++ b/src/draw.js
@@ -173,16 +173,18 @@ export default class Draw extends mapboxgl.Control {
   }
 
   _edit(drawId) {
-    this._store.edit(drawId);
 
     this._map.getContainer().addEventListener('mousedown', this.initiateDrag, true);
 
-    this.deleteBtn = this._createButton({
-      className: 'mapboxgl-ctrl-draw-btn trash',
-      title: `delete`,
-      fn: this._destroy.bind(this),
-      id: 'deleteBtn'
-    });
+    if (!this._editStore.inProgress())
+      this.deleteBtn = this._createButton({
+        className: 'mapboxgl-ctrl-draw-btn trash',
+        title: `delete`,
+        fn: this._destroy.bind(this),
+        id: 'deleteBtn'
+      });
+
+    this._store.edit(drawId);
   }
 
   _finishEdit() {

--- a/src/draw.js
+++ b/src/draw.js
@@ -7,7 +7,6 @@ import EditStore from './edit_store';
 import themeEdit from './theme/edit';
 import themeStyle from './theme/style';
 import themeDrawing from './theme/drawing';
-//import { LngLat, LngLatBounds } from 'mapbox-gl';
 
 // Data store
 import Store from './store';
@@ -37,7 +36,6 @@ export default class Draw extends mapboxgl.Control {
 
     mapboxgl.util.setOptions(this, options);
 
-    //this.editIds = [];
 
     // event listeners
     this.drag = this._drag.bind(this);
@@ -46,10 +44,6 @@ export default class Draw extends mapboxgl.Control {
     this.endDrag = this._endDrag.bind(this);
     this.initiateDrag = this._initiateDrag.bind(this);
 
-
-    //this.onKeyDown = this._onKeyDown.bind(this);
-    //this.onMouseDown = this._onMouseDown.bind(this);
-    //this.onMouseUp = this._onMouseUp.bind(this);
   }
 
   onAdd(map) {
@@ -110,13 +104,6 @@ export default class Draw extends mapboxgl.Control {
     return container;
   }
 
-  //_onKeyDown(e) {
-  //  if (e.keyCode === 16) {
-  //    this.shiftDown = true;
-  //  }
-  //}
-
-
   _onKeyUp(e) {
 
     // draw shortcuts
@@ -165,29 +152,6 @@ export default class Draw extends mapboxgl.Control {
     }
   }
 
-  //_onMouseDown(e) {
-  //  if (!this.shiftDown) return;
-  //  this.featInStart = DOM.mousePos(e, this._map.getContainer());
-  //}
-
-  //_onMouseUp(e) {
-  //  if (!this.shiftDown) return;
-  //  var end = DOM.mousePos(e, this._map.getContainer());
-
-  //  var ne = this.featInStart.x > end.x ? this.featInStart : end;
-  //  var sw = this.featInStart.x > end.x ? end : this.featInStart;
-
-  //  ne = this._map.unproject(ne);
-  //  sw = this._map.unproject(sw);
-
-  //  var bounds = new LngLatBounds(
-  //    new LngLat(sw.lng, sw.lat),
-  //    new LngLat(ne.lng, ne.lat)
-  //  );
-  //  var feats = this._store.getFeaturesIn(bounds);
-  //  this._batchEdit(feats.map(feat => feat.drawId));
-  //}
-
   /**
    * Handles clicks on the maps in a number of scenarios
    * @param {Object} e - the object passed to the callback of map.on('click', ...)
@@ -209,49 +173,7 @@ export default class Draw extends mapboxgl.Control {
     });
   }
 
-
-  //_onClick(e) {
-
-  //  this._map.featuresAt(e.point, {
-  //    radius: 10,
-  //    includeGeometry: true,
-  //    layer: 'gl-draw-polygons'
-  //  }, (err, features) => {
-  //    if (err) throw err;
-
-  //    if (features.length) { // clicked on a feature
-  //      //if (this._editStore.inProgress() && !this.editIds.length) { // clicked on a feature while in draw mode
-  //      if (this._editStore.drawing) {
-  //        return;
-  //      } else if (this._editStore.inProgress() && /*this.editIds.length*/this._editStore.editting) { // clicked on a feature while in edit mode
-  //        if (features[0].properties.drawId === /*this.editIds.length*/this._editStore.activeId) { // clicked on the feature you're editing
-  //          return;
-  //        } else { // clicked on a different feature while in edit mode
-  //          this._finish();
-  //          //this.editIds = [];
-  //          this._editStore.clear();
-  //        }
-  //      }
-  //    } else { // clicked not on a feature
-  //      if (!this._editStore.inProgress()) { // click outside features while not drawing or editing
-  //        return;
-  //      } else if (/*this._editStore.inProgress() && !this.editIds.length*/this._editStore.drawing) { // clicked outside features while drawing
-  //        return;
-  //      } else if (/*this.editIds.length*/this._editStore.editting) { // clicked outside features while editing
-  //        return this._finish();
-  //      }
-  //    }
-
-  //    // if (clicked on a feature && ((!editing this feature && !drawing))
-  //    this._edit(features[0].properties.drawId);
-  //  });
-
-  //}
-
   _edit(drawId) {
-    //this.editIds.push(drawId);
-    //var feat = this._store.edit(drawId);
-    //this._editStore.set(feat);
     this._store.edit(drawId);
 
     this._map.getContainer().addEventListener('mousedown', this.initiateDrag, true);
@@ -264,43 +186,13 @@ export default class Draw extends mapboxgl.Control {
     });
   }
 
-  /**
-   * @param {Array<String>} features - an array of drawIds
-   * @private
-   */
-  //_batchEdit(drawIds) {
-  //  this._finish();
-  //  //this.editIds = drawIds;
-  //  //this.editIds
-  //  //  .map(id => this._store.edit(id))
-  //  //  .forEach(feat => { this._editStore.set(feat); });
-  //  this._store.editBatch(drawIds);
-
-  //  this.deleteBtn = this._createButton({
-  //    className: 'mapboxgl-ctrl-draw-btn trash',
-  //    title: 'delete all features in edit mode',
-  //    fn: this._destroyAll.bind(this),
-  //    id: 'deleteBtn'
-  //  });
-  //}
-
   _finishEdit() {
-    /*
-    if (this.editIds.length) {
-      for (var i = 0; i < this.editIds.length; i++) {
-        this._editStore.get(this.editIds[i]).completeEdit();
-      }
-    } else if (this._editStore.inProgress()) {
-      this._editStore.getAll()[0].completeDraw();
-    }
-    */
     this._editStore.finish();
   }
 
   _exitEdit() {
     DOM.destroy(this.deleteBtn);
     this._map.getContainer().removeEventListener('mousedown', this.initiateDrag, true);
-    //this.editIds = []; // REVISIT
   }
 
   _initiateDrag(e) {
@@ -363,9 +255,6 @@ export default class Draw extends mapboxgl.Control {
   }
 
   _destroy() {
-    //for (var i = 0; i < this.editIds.length; i++) {
-    //  this._editStore.endEdit(this.editIds[i]);
-    //}
     this._exitEdit();
   }
 

--- a/src/draw.js
+++ b/src/draw.js
@@ -141,7 +141,7 @@ export default class Draw extends mapboxgl.Control {
         this._finishEdit();
         break;
       case DELETE_KEY:
-        if (this.editIds.length) {
+        if (this._editStore.inProgress()) {
           this._destroy();
         }
         break;
@@ -358,8 +358,6 @@ export default class Draw extends mapboxgl.Control {
         this._store.set(e.geometry);
         DOM.removeClass(document.querySelectorAll('.' + controlClass), 'active');
       });
-
-      //this._map.on('edit.end', this._exitEdit.bind(this));
 
       this._map.on('new.drawing.update', e => {
         this._map.getSource('drawing').setData(e.geojson);

--- a/src/draw.js
+++ b/src/draw.js
@@ -180,19 +180,23 @@ export default class Draw extends mapboxgl.Control {
     this.deleteBtn = this._createButton({
       className: 'mapboxgl-ctrl-draw-btn trash',
       title: `delete`,
-      fn: this._destroy.bind(this, drawId),
+      fn: this._destroy.bind(this),
       id: 'deleteBtn'
     });
   }
 
   _finishEdit() {
-    this._editStore.finish();
+    if (this._editStore.inProgress()) {
+      this._editStore.finish();
+      DOM.destroy(this.deleteBtn);
+      this._map.getContainer().removeEventListener('mousedown', this.initiateDrag, true);
+    }
   }
 
-  _exitEdit() {
-    DOM.destroy(this.deleteBtn);
-    this._map.getContainer().removeEventListener('mousedown', this.initiateDrag, true);
-  }
+  //_exitEdit() {
+  //  DOM.destroy(this.deleteBtn);
+  //  this._map.getContainer().removeEventListener('mousedown', this.initiateDrag, true);
+  //}
 
   _initiateDrag(e) {
     var coords = DOM.mousePos(e, this._map._container);
@@ -254,12 +258,9 @@ export default class Draw extends mapboxgl.Control {
   }
 
   _destroy() {
-    this._exitEdit();
-  }
-
-  _destroyAll() {
     this._editStore.clear();
-    this._exitEdit();
+    DOM.destroy(this.deleteBtn);
+    this._map.getContainer().removeEventListener('mousedown', this.initiateDrag, true);
   }
 
   _drawPolygon() {
@@ -353,7 +354,7 @@ export default class Draw extends mapboxgl.Control {
         DOM.removeClass(document.querySelectorAll('.' + controlClass), 'active');
       });
 
-      this._map.on('edit.end', this._exitEdit.bind(this));
+      //this._map.on('edit.end', this._exitEdit.bind(this));
 
       this._map.on('new.drawing.update', e => {
         this._map.getSource('drawing').setData(e.geojson);

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -28,7 +28,7 @@ export default class EditStore {
   }
 
   set(geometry) {
-    this.features[geometry.drawId] = geometry;
+    this._features[geometry.drawId] = geometry;
     this._render();
   }
 
@@ -43,7 +43,7 @@ export default class EditStore {
   getAllGeoJSON() {
     return {
       type: 'FeatureCollection',
-      features: Object.keys(this._features).map(id => this.features[id].toGeoJSON())
+      features: Object.keys(this._features).map(id => this._features[id].toGeoJSON())
     };
 
   }

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -12,22 +12,17 @@
  */
 export default class EditStore {
 
-  constructor(map/*, features*/) {
+  constructor(map) {
     this._map = map;
-    //this.features = features || [];
     this._features = {};
 
     this.drawStore = null;
-    //this.editting = false;
-    //this.drawing = false;
 
     this._map.on('new.edit', () => {
       this._render();
     });
 
     this._map.on('finish.edit', () => {
-      //this.features = [];
-      //this.features = {};
       this._render();
     });
 
@@ -41,29 +36,11 @@ export default class EditStore {
   }
 
   set(geometry) {
-    /*
-    if (geometry instanceof Array) {
-      this.features = this.features.concat(geometry);
-    } else {
-      this.features.push(geometry);
-    }
-    */
     this.features[geometry.drawId] = geometry;
-    //this.activeId = geometry.editId;
-    //this.editting = true;
     this._render();
   }
 
-  //setBatch(geoms) {
-  //  this.features = this.features.concat(geoms);
-  //  this._render();
-  //}
-
   finish() {
-    //for (var i = 0; i < this.features.length; i++) {
-    //  this.drawStore.set(this.features[i]);
-    //}
-    //this.features = [];
     for (var id in this._features) {
       this._drawStore.set(this._features[id]);
       delete this._features[id];
@@ -71,15 +48,7 @@ export default class EditStore {
     this._render();
   }
 
-  //getAll() {
-  //  return this.features;
-  //}
-
   getAllGeoJSON() {
-    //return {
-    //  type: 'FeatureCollection',
-    //  features: this.features.map(feature => feature.getGeoJSON())
-    //};
     return {
       type: 'FeatureCollection',
       features: Object.keys(this._features).map(id => this.features[id].toGeoJSON())
@@ -88,34 +57,21 @@ export default class EditStore {
   }
 
   get(id) {
-    //return this.features.filter(feat => feat.drawId === id)[0];
     return this._features[id];
   }
 
   getGeoJSON(id) {
-    //return this.features.filter(feat => feat.drawId === id)[0].getGeoJSON();
     return this._features[id].toGeoJSON();
   }
 
-  //endEdit(id) {
-  //  this.features = this.features.filter(feat => feat.drawId !== id);
-  //  this._render();
-  //}
-
   clear() {
-    //this.features = [];
     this.features = {};
     this._render();
   }
 
-  //inProgress() {
-  //  return this.features.length > 0;
-  //}
-
   _addVertices() {
     var vertices = [];
 
-    //for (var i = 0; i < this.features.length; i++) {
     for (var id in this.features) {
       var coords = this.features[id].toGeoJSON().geometry.coordinates;
       var type = this.features[id].toGeoJSON().geometry.type;
@@ -144,7 +100,6 @@ export default class EditStore {
   _addMidpoints() {
     var midpoints = [];
 
-    //for (var i = 0; i < this.features.length; i++) {
     for (var id in this.features) {
       if (this.features[id].type === 'square') continue;
 

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -52,12 +52,16 @@ export default class EditStore {
     return this._features[id];
   }
 
+  inProgress() {
+    return Object.keys(this._features).length > 0;
+  }
+
   getGeoJSON(id) {
     return this._features[id].toGeoJSON();
   }
 
   clear() {
-    this.features = {};
+    this._features = {};
     this._render();
   }
 

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -18,17 +18,9 @@ export default class EditStore {
 
     this.drawStore = null;
 
-    this._map.on('new.edit', () => {
-      this._render();
-    });
-
-    this._map.on('finish.edit', () => {
-      this._render();
-    });
-
-    this._map.on('edit.end', e => {
-      this.endEdit(e.geometry.drawId);
-    });
+    this._map.on('new.edit', () => { this._render(); });
+    this._map.on('finish.edit', () => { this._render(); });
+    this._map.on('edit.end', e => { this.endEdit(e.geometry.drawId); });
   }
 
   setDrawStore(drawStore) {

--- a/src/edit_store.js
+++ b/src/edit_store.js
@@ -60,6 +60,10 @@ export default class EditStore {
     return this._features[id].toGeoJSON();
   }
 
+  getDrawIds() {
+    return Object.keys(this._features);
+  }
+
   clear() {
     this._features = {};
     this._render();
@@ -68,9 +72,9 @@ export default class EditStore {
   _addVertices() {
     var vertices = [];
 
-    for (var id in this.features) {
-      var coords = this.features[id].toGeoJSON().geometry.coordinates;
-      var type = this.features[id].toGeoJSON().geometry.type;
+    for (var id in this._features) {
+      var coords = this._features[id].toGeoJSON().geometry.coordinates;
+      var type = this._features[id].toGeoJSON().geometry.type;
       if (type === 'LineString' || type === 'Polygon') {
         coords = type === 'Polygon' ? coords[0] : coords;
         var l = type === 'LineString' ? coords.length : coords.length - 1;
@@ -79,6 +83,7 @@ export default class EditStore {
             type: 'Feature',
             properties: {
               meta: 'vertex',
+              parent: this._features[id].drawId,
               index: j
             },
             geometry: {
@@ -96,16 +101,16 @@ export default class EditStore {
   _addMidpoints() {
     var midpoints = [];
 
-    for (var id in this.features) {
-      if (this.features[id].type === 'square') continue;
+    for (var id in this._features) {
+      if (this._features[id].type === 'square') continue;
 
-      var feat = this.features[id];
-      var c = feat.getGeoJSON().geometry.coordinates;
+      var feat = this._features[id];
+      var c = feat.toGeoJSON().geometry.coordinates;
 
-      if (feat.getGeoJSON().geometry.type === 'LineString' ||
-          feat.getGeoJSON().geometry.type === 'Polygon') {
+      if (feat.toGeoJSON().geometry.type === 'LineString' ||
+          feat.toGeoJSON().geometry.type === 'Polygon') {
 
-        c = feat.getGeoJSON().geometry.type === 'Polygon' ? c[0] : c;
+        c = feat.toGeoJSON().geometry.type === 'Polygon' ? c[0] : c;
 
         for (var j = 0; j < c.length - 1; j++) {
           var ptA = this._map.project([ c[j][0], c[j][1] ]);
@@ -115,6 +120,7 @@ export default class EditStore {
             type: 'Feature',
             properties: {
               meta: 'midpoint',
+              parent: feat.drawId,
               index: j + 1
             },
             geometry: {

--- a/src/geometries/geometry.js
+++ b/src/geometries/geometry.js
@@ -38,7 +38,7 @@ export default class Geometry {
    * @return {Object} GeoJSON feature
    * @private
    */
-  getGeoJSON() {
+  toGeoJSON() {
     this.geojson.geometry.coordinates = this.coordinates.toJS();
     return this.geojson;
   }
@@ -117,6 +117,12 @@ export default class Geometry {
       new LngLat(ext[0], ext[1]),
       new LngLat(ext[2], ext[3])
     );
+  }
+
+  _renderDrawProgress() {
+    this._map.fire('new.drawing.update', {
+      geojson: this.toGeoJSON
+    });
   }
 
 }

--- a/src/geometries/geometry.js
+++ b/src/geometries/geometry.js
@@ -98,7 +98,7 @@ export default class Geometry {
   translate(init, curr) {
     if (!this.translating) {
       this.translating = true;
-      this.initGeom = JSON.parse(JSON.stringify(this.getGeoJSON()));
+      this.initGeom = JSON.parse(JSON.stringify(this.toGeoJSON()));
     }
 
     var translatedGeom = translate(JSON.parse(
@@ -114,7 +114,7 @@ export default class Geometry {
   }
 
   getExtent() {
-    var ext = extent(this.getGeoJSON());
+    var ext = extent(this.toGeoJSON());
     return new LngLatBounds(
       new LngLat(ext[0], ext[1]),
       new LngLat(ext[2], ext[3])

--- a/src/geometries/geometry.js
+++ b/src/geometries/geometry.js
@@ -74,9 +74,9 @@ export default class Geometry {
    * Called after a draw is done
    * @private
    */
-  _done(type) {
-    this._map.fire('finish.edit');
-    this._map.fire('draw.end', {
+  _finishDrawing(type) {
+    //this._map.fire('finish.edit');
+    this._map.fire('drawing.end', {
       geometry: this,
       featureType: type
     });
@@ -85,9 +85,9 @@ export default class Geometry {
   /**
    * Clear the edit drawings and render the changes to the main draw layer
    */
-  completeEdit() {
-    this._map.fire('edit.end', { geometry: this });
-  }
+  //completeEdit() {
+  //  this._map.fire('edit.end', { geometry: this });
+  //}
 
   /**
    * Translate this polygon
@@ -101,11 +101,13 @@ export default class Geometry {
       this.initGeom = JSON.parse(JSON.stringify(this.getGeoJSON()));
     }
 
-    var translatedGeom = translate(JSON.parse(JSON.stringify(this.initGeom)), init, curr, this._map);
+    var translatedGeom = translate(JSON.parse(
+          JSON.stringify(this.initGeom)), init, curr, this._map);
     this.coordinates = Immutable.List(translatedGeom.geometry.coordinates);
     if (this.coordinates.get(0).length > 1) {
       // you should be ashamed of yourself
-      this.coordinates = this.coordinates.set(0, Immutable.List(this.coordinates.get(0)));
+      this.coordinates = this.coordinates.set(
+          0, Immutable.List(this.coordinates.get(0)));
     }
 
     this._map.fire('new.edit');
@@ -121,7 +123,7 @@ export default class Geometry {
 
   _renderDrawProgress() {
     this._map.fire('new.drawing.update', {
-      geojson: this.toGeoJSON
+      geojson: this.toGeoJSON()
     });
   }
 

--- a/src/geometries/line.js
+++ b/src/geometries/line.js
@@ -45,7 +45,8 @@ export default class Line extends Geometry {
     }
     this.vertexIdx++;
 
-    this._map.fire('new.edit');
+    //this._map.fire('new.edit');
+    this._renderDrawProgress();
   }
 
   _onMouseMove(e) {

--- a/src/geometries/line.js
+++ b/src/geometries/line.js
@@ -65,7 +65,7 @@ export default class Line extends Geometry {
 
     this.coordinates = this.coordinates.remove(this.vertexIdx);
 
-    this._done('line');
+    this._finishDrawing('line');
   }
 
   /**

--- a/src/geometries/point.js
+++ b/src/geometries/point.js
@@ -31,7 +31,7 @@ export default class Point extends Geometry {
     this._map.getContainer().classList.remove('mapboxgl-draw-activated');
     this._map.off('click', this.completeDraw);
     this.coordinates = Immutable.List([ e.lngLat.lng, e.lngLat.lat ]);
-    this._done('point');
+    this._finishDrawing('point');
   }
 
 }

--- a/src/geometries/polygon.js
+++ b/src/geometries/polygon.js
@@ -78,7 +78,7 @@ export default class Polygon extends Geometry {
     this._map.getContainer().removeEventListener('mousemove', this.onMouseMove);
     this._map.getContainer().classList.remove('mapboxgl-draw-activated');
 
-    this._done('polygon');
+    this._finishDrawing('polygon');
   }
 
   /**

--- a/src/geometries/polygon.js
+++ b/src/geometries/polygon.js
@@ -16,7 +16,8 @@ export default class Polygon extends Geometry {
 
   constructor(map, data) {
     if (!data) data = { geometry: {} };
-    data.geometry.coordinates = Immutable.fromJS(data.geometry.coordinates || [[[0, 0],[0, 0], [0, 0], [0, 0]]]);
+    data.geometry.coordinates = Immutable.fromJS(
+        data.geometry.coordinates || [[[0, 0],[0, 0], [0, 0], [0, 0]]]);
     super(map, 'Polygon', data);
 
     // event handlers
@@ -61,7 +62,8 @@ export default class Polygon extends Geometry {
     var coords = this._map.unproject([pos.x, pos.y]);
     this.coordinates = this.coordinates.setIn([0, this.vertexIdx], [coords.lng, coords.lat]);
 
-    this._map.fire('new.edit');
+    //this._map.fire('new.edit');
+    this._renderDrawProgress();
   }
 
   _completeDraw() {

--- a/src/geometries/square.js
+++ b/src/geometries/square.js
@@ -62,7 +62,8 @@ export default class Square extends Geometry {
     this.coordinates = this.coordinates.setIn([0, 2], [ c.lng, c.lat ]);
     this.coordinates = this.coordinates.setIn([0, 3], [ sw.lng, sw.lat ]);
 
-    this._map.fire('new.edit');
+    //this._map.fire('new.edit');
+    this._renderDrawProgress();
   }
 
   _completeDraw() {

--- a/src/geometries/square.js
+++ b/src/geometries/square.js
@@ -71,7 +71,7 @@ export default class Square extends Geometry {
     this._map.getContainer().removeEventListener('mousemove', this.onMouseMove, true);
     this._map.getContainer().removeEventListener('mouseup', this.completeDraw, true);
 
-    this._done('square');
+    this._finshDrawing('square');
   }
 
   moveVertex(init, curr, idx) {

--- a/src/geometries/square.js
+++ b/src/geometries/square.js
@@ -71,7 +71,7 @@ export default class Square extends Geometry {
     this._map.getContainer().removeEventListener('mousemove', this.onMouseMove, true);
     this._map.getContainer().removeEventListener('mouseup', this.completeDraw, true);
 
-    this._finshDrawing('square');
+    this._finishDrawing('square');
   }
 
   moveVertex(init, curr, idx) {

--- a/src/store.js
+++ b/src/store.js
@@ -55,7 +55,7 @@ export default class Store {
    * @param {String} id - feature id
    */
   unset(id) {
-    delete this._feature[id];
+    delete this._features[id];
     this._render();
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -14,7 +14,7 @@ export default class Store {
     this._map = map;
     this._features = {};
     this._editStore = null;
-    this._map.on('draw.end', e => {
+    this._map.on('drawing.end', e => {
       this.set(e.geometry);
     });
   }

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import Immutable from 'immutable';
+//import Immutable from 'immutable';
 
 /**
  * A store for keeping track of versions of drawings
@@ -10,52 +10,67 @@ import Immutable from 'immutable';
  */
 export default class Store {
 
-  constructor(map, data) {
+  constructor(map) {
     this._map = map;
-    this.historyIndex = 0;
-    this.history = [ Immutable.List([]) ];
-    this.annotations = Immutable.List([]);
-
-    if (data.length) {
-      for (var i = 0; i < data.length; i++) {
-        this.history[0] = this.history[0].push(data[i]);
-      }
-    }
-
-    this._map.on('edit.end', e => {
+    this._features = {};
+    this._editStore = null;
+    this._map.on('draw.end', e => {
       this.set(e.geometry);
     });
+    //this.historyIndex = 0;
+    //this.history = [ Immutable.List([]) ];
+    //this.annotations = Immutable.List([]);
+
+    //if (data.length) {
+    //  for (var i = 0; i < data.length; i++) {
+    //    this.history[0] = this.history[0].push(data[i]);
+    //  }
+    //}
+
+    //this._map.on('edit.end', e => {
+    //  this.set(e.geometry);
+    //});
   }
 
-  _operation(fn, annotation) {
-    // Wrap an operation: Given a function, apply it the history list.
-    // via http://www.macwright.org/2015/05/18/practical-undo.html
-    this.annotations = this.annotations.slice(0, this.historyIndex + 1);
-    this.history = this.history.slice(0, this.historyIndex + 1);
-    var newVersion = fn(this.history[this.historyIndex]);
-    this.history.push(newVersion);
-    this.annotations = this.annotations.push(annotation);
-    this.historyIndex++;
-    this._render();
+  setEditStore(editStore) {
+    this._editStore = editStore;
   }
+
+  //_operation(fn, annotation) {
+  //  // Wrap an operation: Given a function, apply it the history list.
+  //  // via http://www.macwright.org/2015/05/18/practical-undo.html
+  //  this.annotations = this.annotations.slice(0, this.historyIndex + 1);
+  //  this.history = this.history.slice(0, this.historyIndex + 1);
+  //  var newVersion = fn(this.history[this.historyIndex]);
+  //  this.history.push(newVersion);
+  //  this.annotations = this.annotations.push(annotation);
+  //  this.historyIndex++;
+  //  this._render();
+  //}
 
   getAll() {
-    return this.history[this.historyIndex];
+    //return this.history[this.historyIndex];
   }
 
   getAllGeoJSON() {
+    //return {
+    //  type: 'FeatureCollection',
+    //  features: this.history[this.historyIndex].map(feature => feature.getGeoJSON()).toJS()
+    //};
     return {
       type: 'FeatureCollection',
-      features: this.history[this.historyIndex].map(feature => feature.getGeoJSON()).toJS()
+      features: Object.keys(this._features).map(k => this._features[k].toGeoJSON())
     };
   }
 
   get(id) {
-    return this.history[this.historyIndex].find(feature => feature.drawId === id);
+    //return this.history[this.historyIndex].find(feature => feature.drawId === id);
+    return this._features[id];
   }
 
   getGeoJSON(id) {
-    return this.get(id).getGeoJSON();
+    //return this.get(id).getGeoJSON();
+    return this._features[id].toGeoJSON();
   }
 
   /**
@@ -64,45 +79,51 @@ export default class Store {
    * @param {LngLatBounds} bounds
    * @private
    */
-  getFeaturesIn(bounds) {
-    var results = [];
-    var features = this.history[this.historyIndex];
-    for (var i = 0; i < features.size; i++) {
-      var ext = features.get(i).getExtent();
-      if (bounds.getNorth() < ext.getSouth() ||
-          bounds.getSouth() > ext.getNorth() ||
-          bounds.getEast() < ext.getWest() ||
-          bounds.getWest() > ext.getEast()) {
-        continue;
-      } else {
-        results.push(features.get(i));
-      }
-    }
-    return results;
-  }
+  //getFeaturesIn(bounds) {
+    //var results = [];
+    //var features = this.history[this.historyIndex];
+    //for (var i = 0; i < features.size; i++) {
+    //  var ext = features.get(i).getExtent();
+    //  if (bounds.getNorth() < ext.getSouth() ||
+    //      bounds.getSouth() > ext.getNorth() ||
+    //      bounds.getEast() < ext.getWest() ||
+    //      bounds.getWest() > ext.getEast()) {
+    //    continue;
+    //  } else {
+    //    results.push(features.get(i));
+    //  }
+    //}
+    //return results;
+  //}
 
   clear() {
-    this._operation(() => Immutable.List([]), 'remove all geometries');
+    //this._operation(() => Immutable.List([]), 'remove all geometries');
+    this._features = {};
+    this._render();
   }
 
-  clearAll() {
-    this.historyIndex = 0;
-    this.history = [Immutable.fromJS([])];
-    this.annotations = Immutable.List([]);
-  }
+  //clearAll() {
+    //this.historyIndex = 0;
+    //this.history = [Immutable.fromJS([])];
+    //this.annotations = Immutable.List([]);
+  //}
 
   /**
    * @param {Object} feature - GeoJSON feature
    */
   set(feature) {
-    this._operation(data => data.push(feature), 'Added a ' + feature.type);
+    //this._operation(data => data.push(feature), 'Added a ' + feature.type);
+    this._features[feature.drawId] = feature;
+    this._render();
   }
 
   /**
    * @param {String} id - feature id
    */
   unset(id) {
-    this._operation(data => data.filterNot(d => d.drawId === id), 'removed feature ' + id);
+    //this._operation(data => data.filterNot(d => d.drawId === id), 'removed feature ' + id);
+    delete this._feature[id];
+    this._render();
   }
 
   /**
@@ -111,13 +132,27 @@ export default class Store {
    * @private
    */
   edit(id) {
-    var data = this.history[this.historyIndex];
-    var geometry = data.find(geom => geom.drawId === id);
-    this.history[++this.historyIndex] = data.filterNot(geom => geom.drawId === id);
+    // remove it from the store
+    //var data = this.history[this.historyIndex];
+    //var geometry = data.find(geom => geom.drawId === id);
+    //this.history[++this.historyIndex] = data.filterNot(geom => geom.drawId === id);
 
+    //this._render();
+
+    //// add it to the editStore
+    //this._editStore.set(geometry);
+    this._editStore.set(this._features[id]);
+    delete this._features[id];
     this._render();
-    return geometry;
   }
+
+  //editBatch(drawIds) {
+    //var data = this.history[this.historyIndex];
+    //var geometries = data.filter(geom => drawIds.indexOf(geom.drawId) > -1);
+    //this.history[++this.historyIndex] = data.filterNot(geom => drawIds.indexOf(geom.drawId) > -1);
+    //this._editStore.setBatch(geometries);
+    //this._render();
+  //}
 
   _render() {
     this._map.fire('draw.feature.update', {
@@ -125,12 +160,12 @@ export default class Store {
     });
   }
 
-  redo() {
-    if (this.historyIndex < this.history.length) this.historyIndex++;
-  }
+  //redo() {
+  //  if (this.historyIndex < this.history.length) this.historyIndex++;
+  //}
 
-  undo() {
-    if (this.historyIndex > 0) this.historyIndex--;
-  }
+  //undo() {
+  //  if (this.historyIndex > 0) this.historyIndex--;
+  //}
 
 }

--- a/src/store.js
+++ b/src/store.js
@@ -17,46 +17,17 @@ export default class Store {
     this._map.on('draw.end', e => {
       this.set(e.geometry);
     });
-    //this.historyIndex = 0;
-    //this.history = [ Immutable.List([]) ];
-    //this.annotations = Immutable.List([]);
-
-    //if (data.length) {
-    //  for (var i = 0; i < data.length; i++) {
-    //    this.history[0] = this.history[0].push(data[i]);
-    //  }
-    //}
-
-    //this._map.on('edit.end', e => {
-    //  this.set(e.geometry);
-    //});
   }
 
   setEditStore(editStore) {
     this._editStore = editStore;
   }
 
-  //_operation(fn, annotation) {
-  //  // Wrap an operation: Given a function, apply it the history list.
-  //  // via http://www.macwright.org/2015/05/18/practical-undo.html
-  //  this.annotations = this.annotations.slice(0, this.historyIndex + 1);
-  //  this.history = this.history.slice(0, this.historyIndex + 1);
-  //  var newVersion = fn(this.history[this.historyIndex]);
-  //  this.history.push(newVersion);
-  //  this.annotations = this.annotations.push(annotation);
-  //  this.historyIndex++;
-  //  this._render();
-  //}
-
   getAll() {
     //return this.history[this.historyIndex];
   }
 
   getAllGeoJSON() {
-    //return {
-    //  type: 'FeatureCollection',
-    //  features: this.history[this.historyIndex].map(feature => feature.getGeoJSON()).toJS()
-    //};
     return {
       type: 'FeatureCollection',
       features: Object.keys(this._features).map(k => this._features[k].toGeoJSON())
@@ -64,55 +35,22 @@ export default class Store {
   }
 
   get(id) {
-    //return this.history[this.historyIndex].find(feature => feature.drawId === id);
     return this._features[id];
   }
 
   getGeoJSON(id) {
-    //return this.get(id).getGeoJSON();
     return this._features[id].toGeoJSON();
   }
 
-  /**
-   * Get all features within a given extent
-   *
-   * @param {LngLatBounds} bounds
-   * @private
-   */
-  //getFeaturesIn(bounds) {
-    //var results = [];
-    //var features = this.history[this.historyIndex];
-    //for (var i = 0; i < features.size; i++) {
-    //  var ext = features.get(i).getExtent();
-    //  if (bounds.getNorth() < ext.getSouth() ||
-    //      bounds.getSouth() > ext.getNorth() ||
-    //      bounds.getEast() < ext.getWest() ||
-    //      bounds.getWest() > ext.getEast()) {
-    //    continue;
-    //  } else {
-    //    results.push(features.get(i));
-    //  }
-    //}
-    //return results;
-  //}
-
   clear() {
-    //this._operation(() => Immutable.List([]), 'remove all geometries');
     this._features = {};
     this._render();
   }
-
-  //clearAll() {
-    //this.historyIndex = 0;
-    //this.history = [Immutable.fromJS([])];
-    //this.annotations = Immutable.List([]);
-  //}
 
   /**
    * @param {Object} feature - GeoJSON feature
    */
   set(feature) {
-    //this._operation(data => data.push(feature), 'Added a ' + feature.type);
     this._features[feature.drawId] = feature;
     this._render();
   }
@@ -121,7 +59,6 @@ export default class Store {
    * @param {String} id - feature id
    */
   unset(id) {
-    //this._operation(data => data.filterNot(d => d.drawId === id), 'removed feature ' + id);
     delete this._feature[id];
     this._render();
   }
@@ -132,40 +69,15 @@ export default class Store {
    * @private
    */
   edit(id) {
-    // remove it from the store
-    //var data = this.history[this.historyIndex];
-    //var geometry = data.find(geom => geom.drawId === id);
-    //this.history[++this.historyIndex] = data.filterNot(geom => geom.drawId === id);
-
-    //this._render();
-
-    //// add it to the editStore
-    //this._editStore.set(geometry);
     this._editStore.set(this._features[id]);
     delete this._features[id];
     this._render();
   }
-
-  //editBatch(drawIds) {
-    //var data = this.history[this.historyIndex];
-    //var geometries = data.filter(geom => drawIds.indexOf(geom.drawId) > -1);
-    //this.history[++this.historyIndex] = data.filterNot(geom => drawIds.indexOf(geom.drawId) > -1);
-    //this._editStore.setBatch(geometries);
-    //this._render();
-  //}
 
   _render() {
     this._map.fire('draw.feature.update', {
       geojson: this.getAllGeoJSON()
     });
   }
-
-  //redo() {
-  //  if (this.historyIndex < this.history.length) this.historyIndex++;
-  //}
-
-  //undo() {
-  //  if (this.historyIndex > 0) this.historyIndex--;
-  //}
 
 }

--- a/src/store.js
+++ b/src/store.js
@@ -23,10 +23,6 @@ export default class Store {
     this._editStore = editStore;
   }
 
-  getAll() {
-    //return this.history[this.historyIndex];
-  }
-
   getAllGeoJSON() {
     return {
       type: 'FeatureCollection',

--- a/src/theme/drawing.js
+++ b/src/theme/drawing.js
@@ -1,0 +1,77 @@
+module.exports = [
+  {
+    'id': 'gl-edit-line',
+    'type': 'line',
+    'source': 'edit',
+    'filter': ['all', ['==', '$type', 'LineString']],
+    'layout': {
+      'line-cap': 'round',
+      'line-join': 'round'
+    },
+    'paint': {
+      'line-color': '#000000',
+      'line-dasharray': [0, 2],
+      'line-width': 3
+    },
+    'interactive': true
+  }, {
+    'id': 'gl-edit-polygon',
+    'type': 'fill',
+    'source': 'edit',
+    'filter': ['all', ['==', '$type', 'Polygon']],
+    'paint': {
+      'fill-color': '#000000',
+      'fill-opacity': 0.25
+    },
+    'interactive': true
+  }, {
+    'id': 'gl-edit-polygon-stroke',
+    'type': 'line',
+    'source': 'edit',
+    'filter': ['all', ['==', '$type', 'Polygon']],
+    'layout': {
+      'line-cap': 'round',
+      'line-join': 'round'
+    },
+    'paint': {
+      'line-color': '#000000',
+      'line-dasharray': [2, 2],
+      'line-width': 3
+    },
+    'interactive': true
+  }, {
+    'id': 'gl-edit-points',
+    'type': 'circle',
+    'source': 'edit',
+    'filter': ['all',
+      ['==', '$type', 'Point'],
+      ['!=', 'meta', 'midpoint']],
+    'layout': {
+      'text-anchor': 'top',
+      'icon-allow-overlap': true
+    },
+    'paint': {
+      'icon-color': '#ffffff',
+      'icon-halo-color': '#000000',
+      'icon-halo-width': 2,
+      'icon-size': 1.1
+    },
+    'interactive': true
+  }, {
+    'id': 'gl-edit-points-mid',
+    'type': 'circle',
+    'source': 'edit',
+    'filter': ['all',
+      ['==', '$type', 'Point'],
+      ['==', 'meta', 'midpoint']],
+    'layout': {
+      'text-anchor': 'top',
+      'icon-allow-overlap': true
+    },
+    'paint': {
+      'icon-color': '#000000',
+      'icon-size': 1
+    },
+    'interactive': true
+  }
+];

--- a/src/theme/drawing.js
+++ b/src/theme/drawing.js
@@ -1,8 +1,8 @@
 module.exports = [
   {
-    'id': 'gl-edit-line',
+    'id': 'gl-drawing-line',
     'type': 'line',
-    'source': 'edit',
+    'source': 'drawing',
     'filter': ['all', ['==', '$type', 'LineString']],
     'layout': {
       'line-cap': 'round',
@@ -15,9 +15,9 @@ module.exports = [
     },
     'interactive': true
   }, {
-    'id': 'gl-edit-polygon',
+    'id': 'gl-drawing-polygon',
     'type': 'fill',
-    'source': 'edit',
+    'source': 'drawing',
     'filter': ['all', ['==', '$type', 'Polygon']],
     'paint': {
       'fill-color': '#000000',
@@ -25,9 +25,9 @@ module.exports = [
     },
     'interactive': true
   }, {
-    'id': 'gl-edit-polygon-stroke',
+    'id': 'gl-drawing-polygon-stroke',
     'type': 'line',
-    'source': 'edit',
+    'source': 'drawing',
     'filter': ['all', ['==', '$type', 'Polygon']],
     'layout': {
       'line-cap': 'round',
@@ -40,12 +40,10 @@ module.exports = [
     },
     'interactive': true
   }, {
-    'id': 'gl-edit-points',
+    'id': 'gl-drawing-points',
     'type': 'circle',
-    'source': 'edit',
-    'filter': ['all',
-      ['==', '$type', 'Point'],
-      ['!=', 'meta', 'midpoint']],
+    'source': 'drawing',
+    'filter': ['all', ['==', '$type', 'Point']],
     'layout': {
       'text-anchor': 'top',
       'icon-allow-overlap': true
@@ -55,22 +53,6 @@ module.exports = [
       'icon-halo-color': '#000000',
       'icon-halo-width': 2,
       'icon-size': 1.1
-    },
-    'interactive': true
-  }, {
-    'id': 'gl-edit-points-mid',
-    'type': 'circle',
-    'source': 'edit',
-    'filter': ['all',
-      ['==', '$type', 'Point'],
-      ['==', 'meta', 'midpoint']],
-    'layout': {
-      'text-anchor': 'top',
-      'icon-allow-overlap': true
-    },
-    'paint': {
-      'icon-color': '#000000',
-      'icon-size': 1
     },
     'interactive': true
   }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -47,9 +47,6 @@ test('API test', t => {
   Draw.clear();
   t.equals(Draw.getAll().features.length, 0, 'Draw.clear removes all geometries');
 
-  Draw.clearAll();
-  t.equals(Draw._store.historyIndex, 0, 'Draw.clearAll resets the history index to 0');
-
   id = Draw.set(feature);
   f = Draw.get(id);
   Draw.remove(f.properties.drawId);

--- a/test/draw.test.js
+++ b/test/draw.test.js
@@ -41,8 +41,7 @@ test('Draw class test', t => {
   t.equals(typeof Draw._onKeyUp,'function', '_onKeyUp method exists');
   t.equals(typeof Draw._onClick, 'function', '_onClick method exists');
   t.equals(typeof Draw._edit, 'function', '_edit method exists');
-  t.equals(typeof Draw._finish, 'function', '_finish method exists');
-  t.equals(typeof Draw._exitEdit, 'function', '_exitEdit method exists');
+  t.equals(typeof Draw._finishEdit, 'function', '_finishEdit method exists');
   t.equals(typeof Draw._initiateDrag, 'function', '_initiateDrag method exists');
   t.equals(typeof Draw._drag, 'function', '_drag method exists');
   t.equals(typeof Draw._endDrag, 'function', '_endDraw method exists');
@@ -56,7 +55,6 @@ test('Draw class test', t => {
   t.equals(typeof Draw.get, 'function', 'get method exists');
   t.equals(typeof Draw.getAll, 'function', 'getAll method exists');
   t.equals(typeof Draw.clear, 'function', 'clear method exists');
-  t.equals(typeof Draw.clearAll, 'function', 'clearAll method exists');
   t.equals(typeof Draw._createButton, 'function', '_createButton method exists');
   t.equals(typeof Draw._mapState, 'function', '_mapState method exists');
 
@@ -97,22 +95,15 @@ test('Draw class test', t => {
     document.getElementById('deleteBtn'),
     'whilst in edit mode, the delete button is added to the DOM'
   );
-  Draw._finish();
-  Draw._exitEdit();
+  Draw._finishEdit();
   t.notOk(
     document.getElementById('deleteBtn'),
     'delete button is removed on at the end of edit'
   );
-  Draw.clearAll();
+  Draw.clear();
 
   // delete feature
-  Draw.set(feature);
-  /*
-  f = Draw.getAll().features[0];
-  Draw._edit(f);
-  Draw._destroy(f.properties.drawId);
-  t.equals(Draw.getAll().features.length, 0, 'Draw._destroy removes the geometry from the store');
-  */
+  //Draw.set(feature);
 
   t.end();
 });

--- a/test/edit_store.test.js
+++ b/test/edit_store.test.js
@@ -41,8 +41,7 @@ test('Edit store constructor', t => {
   var editStore = new EditStore(map);
 
   // are they even there?
-  t.equals(typeof editStore.get, 'function', 'getById exists');
-  t.equals(typeof editStore.getAll, 'function', 'get exists');
+  t.equals(typeof editStore.get, 'function', 'get exists');
   t.equals(typeof editStore.clear, 'function', 'clear exists');
   t.equals(typeof editStore._addVertices, 'function', '_addVertices exists');
   t.equals(typeof editStore._addMidpoints, 'function', '_addMidpoints exists');

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -2,7 +2,6 @@ var Store = require('../src/store');
 var test = require('tape');
 var mapboxgl = require('mapbox-gl');
 var GLDraw = require('../');
-var Immutable = require('immutable');
 
 mapboxgl.accessToken = 'pk.eyJ1IjoibWFwYm94IiwiYSI6IlhHVkZmaW8ifQ.hAMX5hSW-QnTeRCMAy9A8Q';
 
@@ -41,30 +40,14 @@ test('Store constructor', t => {
 
   var store = Draw._store;
 
-  t.equals(store.historyIndex, 0, 'historyIndex starts at zero');
-  t.ok(store.history, 'history exists');
-  t.equals(store.history.length, 1, 'history has one element');
-  t.ok(store.history[0] instanceof Immutable.List, 'history has a list');
-  t.equals(store.history[0].count(), 0, 'history\'s list is empty');
-
-  t.ok(store.annotations, 'annotations exists');
-  t.ok(store.annotations instanceof Immutable.List, 'annotations has a list');
-  t.equals(store.annotations.size, 0, 'annotations list is empty');
-
   // are the methods even there?
-  t.equals(typeof store._operation, 'function', '_operation exists');
-  t.equals(typeof store.getAll, 'function', 'getAll exists');
   t.equals(typeof store.get, 'function', 'get exists');
+  t.equals(typeof store.getAllGeoJSON, 'function', 'getAllGeoJSON exists');
   t.equals(typeof store.clear, 'function', 'clear exists');
-  t.equals(typeof store.clearAll, 'function', 'clearAll exists');
   t.equals(typeof store.unset, 'function', 'unset exists');
   t.equals(typeof store.set, 'function', 'set exists');
   t.equals(typeof store.edit, 'function', 'edit exists');
   t.equals(typeof store._render, 'function', '_render exists');
-  t.equals(typeof store.redo, 'function', 'redo exists');
-  t.equals(typeof store.undo, 'function', 'undo exists');
-
-  t.ok(store.getAll() instanceof Immutable.List, 'history initiates with an empty Immutable.List');
 
   // set
   var id = Draw.set(feature);
@@ -74,7 +57,7 @@ test('Store constructor', t => {
 
   // get
   var storeFeat = store.get(f.properties.drawId);
-  t.deepEqual(storeFeat.getGeoJSON().geometry, feature.geometry, 'get returns the same geometry you set');
+  t.deepEqual(storeFeat.toGeoJSON().geometry, feature.geometry, 'get returns the same geometry you set');
 
   // unset
   store.unset(f.properties.drawId);


### PR DESCRIPTION
This PR does a lot of different things, but mostly, it simplifies and cleans up [draw.js][draw], [store.js][store], and [edit_store.js][edit] a great deal by using much more sensible data structures to keep tabs of the state of the geometries. This results in A LOT less code (over 150 lines less with greatly reduced bugginess)!

It also removes history, undo, and redo for the sake for simplicity for the time being.

re: #77, #21 

[draw]: https://github.com/mapbox/gl-draw/blob/master/src/draw.js
[store]: https://github.com/mapbox/gl-draw/blob/master/src/store.js
[edit]: https://github.com/mapbox/gl-draw/blob/master/src/edit_store.js
